### PR TITLE
Ditch the Python module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,22 @@ Forge](http://img.shields.io/puppetforge/v/praekeltfoundation/certbot.svg?style=
 Puppet module to manage the [EFF](https://www.eff.org/)'s client for [Let's Encrypt](https://letsencrypt.org/), [Certbot](https://certbot.eff.org/)
 
 ## Why?
-There are a few Puppet modules out there for Certbot/Letsencrypt. Why have we written our own one? Other than a lack of maintenance on some of the existing modules, ours differs in that:
+There are a few Puppet modules out there for Certbot/Let's Encrypt. Why have we written our own one? Other than a lack of maintenance on some of the existing modules, ours differs in that:
 * It installs Certbot from PyPI using `pip` in a virtualenv so that you can install the latest version
-* It runs Certbot as a non-root user with limited privileges
-* It automates more of the steps around enabling HTTPS for an Nginx server with Let's Encrypt certificates
+* It runs Certbot as a non-root user with limited privileges by default
+* It automates all of the steps around enabling HTTPS for an Nginx server with Let's Encrypt certificates
 
 ## Warning
 We don't recommend you use this in production just yet for the following reasons:
 * There are no real tests yet
 * We've only used this on Debian 8 (Jessie)
-* We've only used this for webroot-based (`http-01`) challenges with Nginx
+* We've only used this for webroot-based (`http-01`) challenges with Nginx and standalone challenges
 * We use some hacky Puppet features (virtual resources) to "auto-magically" set up SSL settings for Nginx servers
 * The code is likely to change substantially
 
 ## Usage
-Set up the basics: install Python and Certbot.
+Set up the basics:
 ```puppet
-class { 'python':
-  virtualenv => present,
-}
-->
 class { 'certbot':
   email => 'letsencrypt@example.com',
 }
@@ -42,15 +38,6 @@ Set up an Nginx server and `certbot::nginx::virtual_server` resource:
 certbot::nginx::virtual_server { 'myserver': }
 ```
 
-After one Puppet run the certificates should be issued. Adjust the `certbot::nginx::virtual_server` resource parameter to enable SSL:
-```puppet
-certbot::nginx::virtual_server { 'myserver': enable_certs => true }
-```
+After one Puppet run the certificates should be issued. Run Puppet once more for the certificates to be used.
 
-It is also possible for this module to manage the Python module:
-```puppet
-class { 'certbot':
-  email         => 'letsencrypt@example.com',
-  manage_python => true,
-}
-```
+Note that by default this module will try to install the package 'python-virtualenv'. If this is not desired, pass `manage_python => false`.

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -53,7 +53,7 @@ define certbot::certonly (
 
   exec { "certbot certonly ${name}":
     command => $_command,
-    path    => ["${certbot::virtualenv}/bin"],
+    path    => ["${certbot::install_dir}/bin"],
     user    => $certbot::user,
     creates => "${_live_path}/cert.pem",
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,44 @@
+# == Class: certbot::install
+#
+# Create the virtualenv and install certbot.
+class certbot::install {
+  assert_private()
+
+  if $certbot::manage_python {
+    package { 'python-virtualenv':
+      ensure => installed,
+    }
+  }
+
+  if $certbot::version {
+    $_install_unless = "pip freeze | grep '^certbot==${$certbot::version}$'"
+  } else{
+    $_install_unless = "python -c 'import certbot'"
+  }
+
+  file { $certbot::install_dir:
+    ensure => directory,
+    owner  => $certbot::user,
+    group  => $certbot::group,
+    mode   => '0755',
+  }
+  -> exec { 'create certbot virtualenv':
+    command => "virtualenv ${certbot::install_dir}",
+    path    => $::path,
+    user    => $certbot::user,
+    creates => "${certbot::install_dir}/bin/python",
+  }
+  -> exec { 'update certbot pip':
+    command => 'pip install --upgrade pip',
+    path    => ["${certbot::install_dir}/bin", $::path],
+    user    => $certbot::user,
+    # Make sure we have pip >= 9.x
+    unless  => "[ $(pip --version | sed -nE 's/^pip ([0-9]+).*/\\1/p') -ge 9 ]"
+  }
+  -> exec { 'install certbot':
+    command => 'pip install certbot',
+    path    => ["${certbot::install_dir}/bin", $::path],
+    user    => $certbot::user,
+    unless  => $_install_unless,
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -17,10 +17,6 @@
       "version_requirement": ">= 1.2.0 < 3.0.0"
     },
     {
-      "name": "stankevich/python",
-      "version_requirement": ">= 1.18.0 < 2.0.0"
-    },
-    {
       "name": "puppet/nginx",
       "version_requirement": ">= 0.6.0 < 1.0.0"
     }


### PR DESCRIPTION
* The existing one doesn't manage wheel installs properly
* The existing one doesn't seem to be maintained currently
* I don't think we use the Python module anywhere else currently
* This also updates the virtualenv path to be just `/opt/letsencrypt` instead of `/opt/letsencrypt/.venv`. The latter was hard to find and it's nice to be able to type `/opt/letsencrypt/bin/certbot`.
  